### PR TITLE
ci: use latest stable version of vercel-action.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v30
+        uses: amondnet/vercel-action@v25.2.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
The Vercel action was downgraded from v30 to v25.2.0 to ensure compatibility and stability in the CI/CD pipeline. This change addresses potential issues introduced by using the wrong version number.